### PR TITLE
Read n bytes from urandom, not always 16

### DIFF
--- a/bcrypt/main.rkt
+++ b/bcrypt/main.rkt
@@ -46,7 +46,7 @@
   (unless (file-exists? "/dev/urandom")
     (error 'bcrypt "/dev/urandom needed for random seed generation"))
   (with-input-from-file "/dev/urandom"
-    (lambda () (read-bytes 16))))
+    (lambda () (read-bytes n))))
 
 (define (encode bs #:rounds [rounds _rounds])
   (define settings (crypt_gensalt_rn PREFIX rounds (urandom 16)))


### PR DESCRIPTION
I know it's always going to be 16, but I saw the error and figured
I might as well submit a pull request.
