### PR TITLE
core: cooperate with raco exe

### DIFF
--- a/bcrypt/main.rkt
+++ b/bcrypt/main.rkt
@@ -1,24 +1,22 @@
 #lang racket/base
 
-(require ffi/unsafe ffi/unsafe/define racket/format)
+(require (for-syntax racket/base)
+         ffi/unsafe
+         ffi/unsafe/define
+         racket/runtime-path)
 (provide encode check match)
 
-(define (local-lib-dirs)
-  (list (build-path (collection-path "bcrypt")
-		    "private"
-		    "compiled"
-		    "native"
-		    (system-library-subpath #f))))
+(define-runtime-path libcrypto_blowfish
+  '(so "libcrypt_blowfish"))
 
-(define bcrypt-lib (ffi-lib "libcrypt_blowfish" #:get-lib-dirs local-lib-dirs))
-
-(define-ffi-definer define-crypt bcrypt-lib)
+(define-ffi-definer define-crypt
+  (ffi-lib libcrypto_blowfish))
 
 ;; These constants taken directly from the source
 (define CRYPT_OUTPUT_SIZE		(+ 7 22 31 1))
 (define CRYPT_GENSALT_OUTPUT_SIZE	(+ 7 22 1))
 
-(define-crypt crypt_rn (_fun _bytes _bytes 
+(define-crypt crypt_rn (_fun _bytes _bytes
                              (out : (_bytes o CRYPT_OUTPUT_SIZE))
                              (_int = CRYPT_OUTPUT_SIZE)
                              -> (r : _int)

--- a/bcrypt/main.rkt
+++ b/bcrypt/main.rkt
@@ -6,11 +6,11 @@
          racket/runtime-path)
 (provide encode check match)
 
-(define-runtime-path libcrypto_blowfish
+(define-runtime-path libcrypt_blowfish
   '(so "libcrypt_blowfish"))
 
 (define-ffi-definer define-crypt
-  (ffi-lib libcrypto_blowfish))
+  (ffi-lib libcrypt_blowfish))
 
 ;; These constants taken directly from the source
 (define CRYPT_OUTPUT_SIZE		(+ 7 22 31 1))

--- a/bcrypt/private/install.rkt
+++ b/bcrypt/private/install.rkt
@@ -1,11 +1,8 @@
 #lang racket/base
 
-(require racket/system)
-(require racket/file)
-(require dynext/file)
-(require dynext/link)
-
-(require file/untgz)
+(require dynext/file
+         dynext/link
+         setup/dirs)
 
 (provide pre-installer)
 
@@ -16,12 +13,9 @@
 
   (parameterize ((current-directory private-path))
     (define unpacked-path (build-path private-path SOURCEDIR))
-    (define shared-object-target-path (build-path private-path
-						  "compiled"
-						  "native"
-						  (system-library-subpath #f)))
-    (define shared-object-target (build-path shared-object-target-path
-					     (append-extension-suffix "libcrypt_blowfish")))
+    (define shared-object-target
+      (build-path (find-lib-dir)
+                  (append-extension-suffix "libcrypt_blowfish")))
 
     (when (file-exists? shared-object-target) (delete-file shared-object-target))
     (define c-sources
@@ -30,7 +24,6 @@
                           "wrapper.c")))
         (build-path unpacked-path c)))
 
-    (make-directory* shared-object-target-path)
     (parameterize ((current-extension-linker-flags
                     (append (current-extension-linker-flags)
                             (list "-O2" "-fomit-frame-pointer" "-funroll-loops"


### PR DESCRIPTION
Previously, executables created with `raco exe` of applications that
use this library would fail due to the call to `collection-path`.
This change fixes that problem by installing the built so into the
Racket lib dir and tracking a runtime path to it rather than relying
on path construction at runtime.